### PR TITLE
Implement key-based navigation

### DIFF
--- a/inselect/key_handler.py
+++ b/inselect/key_handler.py
@@ -1,0 +1,79 @@
+from PySide import QtCore
+
+
+class KeyHandler(object):
+    """ Mixin used to map key combinations to methods.
+
+    The mixin implements the Qt keyPressEvent method, so classes should not implement their own.
+    """
+    def __init__(self, parent_class):
+        self._handlers = {}
+        self._parent_class = parent_class
+
+    def add_key_handler(self, key, callback, *args):
+        """Add a new key handler
+
+        Parameters
+        ----------
+        key : int, tuple
+            Either a key constant, or a tuple defining a modifier constant and a key constant
+        callback : function
+            Function to call on key press
+        *args
+            Additional arguments will be passed to the callback method
+        """
+        (modifier, key_code) = self._get_key_code(key)
+        if modifier not in self._handlers:
+            self._handlers[modifier] = {}
+        if key_code not in self._handlers[modifier]:
+            self._handlers[modifier][key_code] = []
+        self._handlers[modifier][key_code].append((callback, args))
+
+    def remove_key_handlers(self, key):
+        """Remove all key handlers associated with the given key
+
+        Parameters
+        ----------
+        key : int, tuple
+            Either a key constant, or a tuple defining a modifier constant and a key constant.
+        """
+        (modifier, key_code) = self._get_key_code(key)
+        try:
+            del self._handlers[modifier][key_code]
+        except (AttributeError, KeyError):
+            pass
+
+    def _get_key_code(self, key):
+        """Return a (modifier, key code) tupple for the given key
+
+        Parameters
+        ----------
+        key : int, tuple
+            Either a key constant, or a tuple defining a modifier constant and a key constant
+
+        Returns
+        -------
+        tuple
+            A (modifier, key code) tuple
+        """
+        if isinstance(key, (list, tuple)):
+            return int(key[0]), int(key[1])
+        else:
+            return int(QtCore.Qt.NoModifier), int(key)
+
+    def keyPressEvent(self, event):
+        """Handle Qt keyPressEvent event
+
+        Call the appropriate method for the key event
+
+        Parameters
+        ----------
+        event : QtEvent
+        """
+        try:
+            handlers = self._handlers[int(event.modifiers())][int(event.key())]
+        except (AttributeError, KeyError):
+            self._parent_class.keyPressEvent(self, event)
+            return
+        for (callback, args) in handlers:
+            callback(*args)


### PR DESCRIPTION
Some notes:
- Navigation is done with previous/next navigation (keys: p/n). This more or less follows rows across the image, starting in the top left corner (the sidebar items have been adjusted to be in the same order). Navigation using cursor keys is not a trivial problem (in particular to ensure all boxes are attainable), and we agreed this was good enough for now;
- For users I thought it made more sense to move the bottom right and top left corners individually (rather than 'resize' the box), as that makes it easier to get the selection right. Bottom right uses shift + cursor keys, while top left uses Control + cursor keys. Might not be the best combination, but we thought we would do it this way and wait for user feedback;
- I added the key handling at the GraphicsView level. I think this definitely makes sense for the navigate/resize keys. Possibly zoom-to-selection (and delete) could be moved at the QMainWindow level, but I thought it fitted better there;
- I removed the numbered labels from the sidebar. The items are sorted on add to make prev/next navigation easy. To keep the labels as growing integers would require updating them all when new items are added. I assumed that once we had annotations these would replace the label anyway.

Available navigation:

p: Previous item
n: Next item
Cursor keys: Move current selection
Shift + Cursor keys: move bottom right corner(s) of current selection
Control + Cursor keys: move top left corner(s) of current selection
z: Zoom to current selection

Additional feature is that the view follows the selection (so pressing n/p - or selecting an item in the sidebar - will cause that box to come into view if it isn't)
