### PR TITLE
Split functionality between GraphicsView and GraphicsScene

### DIFF
--- a/inselect/gui/annotator.py
+++ b/inselect/gui/annotator.py
@@ -1,18 +1,22 @@
 from PySide import QtCore, QtGui
 import inselect.settings
 
+DIALOG_PARENT_RATIO = 0.75
 DIALOG_HEADER_HEIGHT = 50
-HELPER_COLUMN_MIN_WIDTH = 200
+SIDEBAR_MIN_WIDTH = 200
+IMAGE_DIALOG_WIDTH_RATIO = 0.5
+IMAGE_DIALOG_HEIGHT_RATIO = 0.9
 
 
 class AnnotateDialog(QtGui.QDialog):
     """ Dialog that handles annotation of a segment. """
-    def __init__(self, segment_scene, segments, parent=None):
+    def __init__(self, graphics_scene, segments, parent=None):
         # Constructors
         super(AnnotateDialog, self).__init__(parent)
         # Setup members
         self._fields = inselect.settings.get('annotation_fields')
-        self._segment_scene = segment_scene
+        self._graphics_scene = graphics_scene
+        self._segment_scene = self._graphics_scene.segment_scene()
         self._parent = parent
         self._image = None
         self._table = None
@@ -21,9 +25,12 @@ class AnnotateDialog(QtGui.QDialog):
         else:
             self._segments = [segments]
         self._single_segment = len(self._segments) == 1
+        self._sidebar_width = SIDEBAR_MIN_WIDTH
         # Setup UI
         self.setWindowTitle('Annotate Segment')
         self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Popup)
+        # Call place_dialog early as we want to know width/height for layout.
+        self._place_dialog()
         self._layout = QtGui.QGridLayout(self)
         self._setup_image()
         self._setup_table()
@@ -40,10 +47,15 @@ class AnnotateDialog(QtGui.QDialog):
                 Note that the values are modified directly as you enter them.
              </span></p>
         """)
-        self._help_text.setFixedWidth(
-            max(inselect.settings.get('icon_size'), HELPER_COLUMN_MIN_WIDTH)
-        )
+        self._help_text.setFixedWidth(self._sidebar_width)
         self._help_text.setWordWrap(True)
+        self._warning_text = QtGui.QLabel("""
+           <p><span style="font-size: 10pt; color: #F00">Warning: You are
+           editing more than one segment. Only values shared by all segments
+           are displayed here.</span></p>
+        """)
+        self._warning_text.setFixedWidth(self._sidebar_width)
+        self._warning_text.setWordWrap(True)
         # Add close/prev/next buttons
         self._button_box = QtGui.QDialogButtonBox(QtCore.Qt.Horizontal)
         self._close_button = QtGui.QPushButton('Close')
@@ -65,10 +77,13 @@ class AnnotateDialog(QtGui.QDialog):
                                    QtCore.Qt.AlignBottom)
             self._layout.addWidget(self._table, 1, 1, 2, 1)
         else:
-            pass
+            self._layout.addWidget(self._warning_text, 1, 0,
+                                   QtCore.Qt.AlignTop)
+            self._layout.addWidget(self._help_text, 2, 0,
+                                   QtCore.Qt.AlignBottom)
+            self._layout.addWidget(self._table, 1, 1, 2, 1)
         self._layout.addWidget(self._button_box, 3, 0, 1, 2)
         self.setLayout(self._layout)
-        self._place_dialog()
 
         # Listen to events
         self._table.itemChanged.connect(self._item_changed)
@@ -93,6 +108,20 @@ class AnnotateDialog(QtGui.QDialog):
         # Start with the table focused
         self._table.setFocus()
 
+    def _place_dialog(self):
+        """Place/size the dialog on the screen
+
+        This will initialize the dialog and sidebar's width, so should be
+        called early.
+        """
+        self.resize(max(500, int(DIALOG_PARENT_RATIO * self._parent.width())),
+                    max(500, int(DIALOG_PARENT_RATIO * self._parent.height())))
+        screen_rect = self._parent.app.desktop().availableGeometry()
+        self.move(screen_rect.center() - self.rect().center())
+        if self._single_segment:
+            self._sidebar_width = self.width() * IMAGE_DIALOG_WIDTH_RATIO
+
+
     def _setup_image(self):
         """Setup and populate the label for this segment
 
@@ -103,9 +132,11 @@ class AnnotateDialog(QtGui.QDialog):
         if self._image is None:
             self._image = QtGui.QLabel(self)
         if self._single_segment:
-            icon = self._segment_scene.get_segment_icon(self._segments[0])
-            size = inselect.settings.get('icon_size')
-            pixmap = icon.pixmap(size, size)
+            pixmap = self._graphics_scene.get_segment_pixmap(
+                self._segments[0], self._sidebar_width,
+                self.height() * IMAGE_DIALOG_HEIGHT_RATIO,
+                border=False, padding=False
+            )
             self._image.setPixmap(pixmap)
 
     def _setup_table(self):
@@ -124,26 +155,25 @@ class AnnotateDialog(QtGui.QDialog):
             self._table.horizontalHeader().setStretchLastSection(True)
             self._table.horizontalHeader().hide()
         # Populate the data
-        # TODO: If multiple segments share a field's value (eg. taxon name),
-        # add it in.
         if self._single_segment:
             segment_values = self._segments[0].fields()
-            for row, field in enumerate(self._fields):
-                if field in segment_values:
-                    value = segment_values[field]
-                else:
-                    value = ''
-                item = QtGui.QTableWidgetItem()
-                item.setData(QtCore.Qt.EditRole, value)
-                self._table.setItem(row, 0, item)
-
-
-    def _place_dialog(self):
-        """Place/size the dialog on the screen"""
-        self.resize(max(500, int(0.66 * self._parent.width())),
-                    max(500, int(0.66 * self._parent.height())))
-        screen_rect = self._parent.app.desktop().availableGeometry()
-        self.move(screen_rect.center() - self.rect().center())
+        else:
+            segment_values = self._segments[0].fields()
+            for i in range(1, len(self._segments)):
+                new_values = self._segments[i].fields()
+                for field, value in new_values.items():
+                    if field not in segment_values:
+                        segment_values[field] = ''
+                    elif segment_values[field] != value:
+                        segment_values[field] = ''
+        for row, field in enumerate(self._fields):
+            if field in segment_values:
+                value = segment_values[field]
+            else:
+                value = ''
+            item = QtGui.QTableWidgetItem()
+            item.setData(QtCore.Qt.EditRole, value)
+            self._table.setItem(row, 0, item)
 
     def _item_changed(self, item):
         """Callback invoked when an item is changed
@@ -164,8 +194,8 @@ class AnnotateDialog(QtGui.QDialog):
         """
         if not self._single_segment:
             return
-        #TODO: select/deselect box. We need API on graphics_scene for this.
         next_segment = self._segment_scene.get_next_segment(self._segments[0])
+        self._graphics_scene.select_segment(next_segment)
         self._segments = [next_segment]
         self._setup_table()
         self._setup_image()
@@ -178,8 +208,8 @@ class AnnotateDialog(QtGui.QDialog):
         """
         if not self._single_segment:
             return
-        #TODO: select/deselect box. We need API on graphics_scene for this.
         p_segment = self._segment_scene.get_previous_segment(self._segments[0])
+        self._graphics_scene.select_segment(p_segment)
         self._segments = [p_segment]
         self._setup_table()
         self._setup_image()

--- a/inselect/gui/box_resizable.py
+++ b/inselect/gui/box_resizable.py
@@ -26,8 +26,6 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
     ----------
     graphics_scene : QtGui.QGraphicsScene
         The graphics scene this box is part of
-    segment_scene : SegmentScene
-        The segment scene used to manage segments in this graphics scene
     segment : Segment
         The segment associated with this box
     parent : object
@@ -38,13 +36,12 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
     scene : QGraphicsScene, optional
         The graphics scene this box belongs to
     """
-    def __init__(self, graphics_scene, segment_scene, segment,
+    def __init__(self, graphics_scene, segment,
                  color=QtCore.Qt.blue, transparent=False):
         # Set up members
         self._graphics_scene = graphics_scene
-        self._segment_scene = segment_scene
         self._segment = segment
-        self._segment_rect = self._segment_scene.get_q_rect_f(segment)
+        self._segment_rect = self._segment.get_q_rect_f()
         self._visible_rect = QtCore.QRectF(self._segment_rect)
         self._bounding_rect = None
         self._handles = {
@@ -160,7 +157,7 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
         segment : Segment
         """
         self._segment = segment
-        self._segment_rect = self._segment_scene.get_q_rect_f(self._segment)
+        self._segment_rect = self._segment.get_q_rect_f()
         # Translate this into this item's coordinate system.
         self._segment_rect.translate(-self.pos().x(), -self.pos().y())
         self.prepareGeometryChange()
@@ -296,8 +293,7 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
     def _end_move_resize(self):
         """End moving/resizing the box"""
         segment_corners = self._map_rect_to_scene(self._segment_rect)
-        self._segment_scene.set_segment_corners(
-            self._segment,
+        self._segment.set_corners(
             (segment_corners.left(), segment_corners.top()),
             (segment_corners.right(), segment_corners.bottom())
         )
@@ -352,6 +348,8 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
         Where (0, 0) is the box coordinates at top left corner of the box,
         the position of the box is added to give the view coordinates.
         """
+        #TODO: Implement this class separately from QGraphicsRectItem
+        #Then we won't need _map_rect_to_scene anymore.
         rect = map_rect
         target_rect = QtCore.QRectF(rect)
         t = rect.topLeft()
@@ -381,7 +379,7 @@ class BoxResizable(MouseHandler, QtGui.QGraphicsRectItem):
             rect = self._segment_rect
             if rect.width() > 0 and rect.height() > 0:
                 target_rect = self._map_rect_to_scene(rect)
-                painter.drawPixmap(rect, self.scene().image.pixmap(),
+                painter.drawPixmap(rect, self._graphics_scene.pixmap(),
                                    target_rect)
 
         radius = self._graphics_scene.width() / 150

--- a/inselect/gui/graphics_scene.py
+++ b/inselect/gui/graphics_scene.py
@@ -1,20 +1,61 @@
-from PySide import QtGui
+from PySide import QtGui, QtCore
 from inselect.gui.box_resizable import BoxResizable
 
 
 class GraphicsScene(QtGui.QGraphicsScene):
     """The GraphicsScene holds all the boxes displayed to the user.
 
+    It handles selecting/deselecting items and generating pixmaps.
+
     The GraphicsScene listens for segments being added/removed to the
     segment scene, and adds/removes BoxResizable items to the scene
     correspondingly.
     """
     def __init__(self, segment_scene):
+        # Constructors
         QtGui.QGraphicsScene.__init__(self)
+        # Setup members
         self._segment_scene = segment_scene
+        self._boxes_with_keyboard_focus = []
+        self._image_item = None
+        self._pixmap = None
+        # Watch modifications on the segment scene
         self._segment_scene.watch('after-segment-add', self._after_segment_add)
         self._segment_scene.watch('before-segment-remove',
                                   self._before_segment_remove)
+
+    def set_image(self, image):
+        """Set the image to work from
+
+        Parameters
+        ----------
+        image : QtCore.QImage
+        """
+        self._pixmap = QtGui.QPixmap.fromImage(image)
+        if self._image_item is None:
+            self._image_item = QtGui.QGraphicsPixmapItem(self._pixmap)
+            self.addItem(self._image_item)
+        else:
+            self._image_item.setPixmap(self._pixmap)
+        self.setSceneRect(0, 0, image.width(), image.height())
+
+    def pixmap(self):
+        """Return the pixmap of this scene
+
+        Returns
+        -------
+        QtGui.QPixmap
+        """
+        return self._pixmap
+
+    def segment_scene(self):
+        """Return the segment scene associated with this graphics scene
+
+        Returns
+        -------
+        SegmentScene
+        """
+        return self._segment_scene
 
     def selected_segments(self):
         """Return the currently selected segments
@@ -29,6 +70,138 @@ class GraphicsScene(QtGui.QGraphicsScene):
             segments.append(segment)
         return segments
 
+    def select_all_segments(self):
+        """Select all segments in the scene"""
+        for box in self.items():
+            box.setSelected(True)
+
+    def deselect_all_segments(self):
+        """Deselect all segments in the scene"""
+        for box in self.selectedItems():
+            box.setSelected(False)
+
+    def select_segment(self, segment, deselect_others=True):
+        """Select the given segment.
+
+        Parameters
+        ----------
+        segment : Segment
+        deselect_others : bool
+            If True (default) then it de-selects other segments first.
+            Otherwise it adds the given segment to the list of selected
+            segments.
+        """
+        if deselect_others:
+            self.deselect_all_segments()
+        box = segment.get_associated_object(BoxResizable)
+        box.setSelected(True)
+
+    def set_keyboard_focus(self, segment, focus):
+        """Indiciate whether a given segment has keyboard focus
+
+        Parameters
+        ----------
+        segment : Segment
+        focus : bool
+        """
+        box = segment.get_associated_object(BoxResizable)
+        box.set_keyboard_focus(focus)
+        self._boxes_with_keyboard_focus.append(box)
+
+    def remove_keyboard_focus(self):
+        """Remove the keyboard focus from all the segments that have it"""
+        for box in self._boxes_with_keyboard_focus:
+            box.set_keyboard_focus(False)
+        self._boxes_with_keyboard_focus = []
+
+    def get_selection_box(self):
+        """Return the bounding box of selected items
+
+        Returns
+        --------
+        tuple : (top_left, bottom_right) where each tuple is formed of (x,y) or
+            None if there is no selection
+        """
+        tl = None
+        br = None
+        for item in self.selectedItems():
+            box = item.boundingRect()
+            if tl is None:
+                tl = (box.left(), box.top())
+                br = (box.right(), box.bottom())
+            else:
+                tl = (min(tl[0], box.left()), min(tl[1], box.top()))
+                br = (max(br[0], box.right()), max(br[1], box.bottom()))
+        if tl is None:
+            return None
+        return tl, br
+
+    def get_segment_pixmap(self, segment, width, height=None, fit=True,
+                           background='#EEE', border=True, padding=16):
+        """Extract a segment's pixmap for use in GUI elements.
+
+        The extracted pixmap is scaled to fit within width*height. If fit
+        is True the returned image will be exactly width*height, with the
+        background filled with the given color.
+
+        Parameters
+        ----------
+        segment : Segment
+        width, height : float or int
+            Dimensions to scale the pixmap to. If height is None, it is set
+            to width (ie. a square)
+        fit : bool
+            If True, the returned image will be exactly width*height
+        background : str or QColor or QBrush
+            If the image was padded (either to make it fit, or for padding)
+            the background is filled with this color
+        border : bool
+            If True, a border is added around the image. This is drawn inside
+            the image, and does not affect the returned width/height
+        padding : int
+            Padding to add around the segment within the returned image. This
+            does not affect the returned width/height
+
+        Returns
+        -------
+        QtGui.QPixmap
+        """
+        # Get the rectangle and calculate the scale factor
+        rect = segment.get_q_rect_f()
+        if height is None:
+            height = width
+        w_scale = (float(width) - float(padding))/rect.width()
+        h_scale = (float(height) - float(padding))/rect.height()
+        scale = min(w_scale, h_scale)
+
+        # Extract the pixmap
+        pixmap = self._pixmap.copy(
+            int(rect.left()), int(rect.top()),
+            int(rect.width()), int(rect.height())
+        )
+        pixmap = pixmap.scaled(
+            pixmap.width() * scale,
+            pixmap.height() * scale,
+            transformMode=QtCore.Qt.SmoothTransformation
+        )
+        if not fit and padding == 0:
+            return pixmap
+        if type(background) is str:
+            background = QtGui.QColor(background)
+        background_pixmap = QtGui.QPixmap(width, height)
+        painter = QtGui.QPainter(background_pixmap)
+        painter.fillRect(QtCore.QRectF(0, 0, width, height), background)
+        painter.drawPixmap(
+            (width - pixmap.width()) / 2,
+            (height - pixmap.height()) / 2,
+            pixmap
+        )
+        if border:
+            painter.setPen(QtCore.Qt.DashLine)
+            painter.drawRect(QtCore.QRectF(0, 0, width - 1, height - 1))
+        painter.end()
+        return background_pixmap
+
     def _after_segment_add(self, segment):
         """Callback invoked when a new segment is added
 
@@ -36,8 +209,8 @@ class GraphicsScene(QtGui.QGraphicsScene):
         ----------
         segment : Segment
         """
-        box = BoxResizable(self, self._segment_scene, segment)
-        self._segment_scene.associate_object('boxResizable', box, segment)
+        box = BoxResizable(self, segment)
+        segment.associate_object(box)
 
     def _before_segment_remove(self, segment):
         """Callback invoked when a segment is removed
@@ -46,5 +219,5 @@ class GraphicsScene(QtGui.QGraphicsScene):
         ----------
         segment : Segment
         """
-        box = self._segment_scene.get_associated_object('boxResizable', segment)
+        box = segment.get_associated_object(BoxResizable)
         self.removeItem(box)

--- a/inselect/lib/segment_object.py
+++ b/inselect/lib/segment_object.py
@@ -1,13 +1,19 @@
+import weakref
+import inspect
+from PySide import QtCore
 from inselect.lib import utils
 
 
-class Segment(object):
-    """This class represents an individual segment, represented by
-    normalized coordinates and a set of field/values.
+class NoAssociatedObject(Exception):
+    """Exception raised when attempting to obtain a non-existent
+    associated object
+    """
+    pass
 
-    The Segment does not store information about the context in which it was
-    created. To use scene co-ordinates, the segment must be created/updated
-    through the SegmentScene.
+
+class Segment(object):
+    """This class represents an individual segment in a scene and a set of
+    field/values.
 
     It is possible to get callbacks invoked when a segment is updated, by
     adding a watcher using `watch`. There are two types of events that can
@@ -19,10 +25,14 @@ class Segment(object):
       corner_a and corner_b should both represent one corner of the box (as an
       (x, y) tuple), such that the two corners are diagonally opposite. These
       will always be re-arranged and stored as (top left, bottom right).
+    scene_size : tuple of float
+        (width, height) of the scene this segments belongs to. If None,
+        it is assume the segment is already normalized (ie. the size
+        is (1, 1))
     fields : dictionary, None
         Fields values for this segment
     """
-    def __init__(self, corner_a, corner_b, fields=None):
+    def __init__(self, corner_a, corner_b, scene_size=None, fields=None):
         self._rect = [[0, 0], [0, 0]]
         self._width = 0
         self._height = 0
@@ -30,15 +40,20 @@ class Segment(object):
             'after-fields-update': [],
             'after-corners-update': []
         }
+        self._objects = {}
         if fields is None:
             self._fields = {}
         else:
             self._fields = dict(fields)
+        if scene_size is None:
+            self._scene_size = (1.0, 1.0)
+        else:
+            self._scene_size = (float(scene_size[0]), float(scene_size[1]))
         self._seeds = []
         self.set_corners(corner_a, corner_b)
 
     def set_corners(self, corner_a, corner_b):
-        """Set the rectangle corners
+        """Set the rectangle corners, for scene co-ordinates
 
         corner_a and corner_b should both represent one corner of the box,
         such that the two corners are diagonally opposite. These will always
@@ -58,7 +73,7 @@ class Segment(object):
             callback(self)
 
     def move_corners(self, top_left_delta, bottom_right_delta=None):
-        """Move the given segment's corners.
+        """Move the given segment's corners, from scene co-ordinates
 
         This will either update both the top left and bottom right corners
         independently (if both top_left_delta and bottom_right_delta) are
@@ -86,6 +101,34 @@ class Segment(object):
             )
         self.set_corners(top_left, bottom_right)
 
+    def set_scene_size(self, width, height):
+        """Set the scene size and scale segment accordingly
+
+        Notes
+        -----
+        This does not trigger a 'after-corners-update' event
+
+        Parameters
+        ----------
+        width, height : float or int
+            New size of the scene
+        """
+        w_factor = self._scene_size[0] / float(width)
+        h_factor = self._scene_size[1] / float(height)
+        self._scene_size = (float(width), float(height))
+        self._rect = [
+            [
+                self._rect[0][0] * w_factor,
+                self._rect[0][1] * h_factor
+            ],
+            [
+                self._rect[1][0] * w_factor,
+                self._rect[1][1] * h_factor
+            ]
+        ]
+        self._width = self._rect[1][0] - self._rect[0][0]
+        self._height = self._rect[1][1] - self._rect[0][1]
+
     def watch(self, watch_type, callback):
         """Add a callback to be invoked when the segment is updated
 
@@ -99,86 +142,163 @@ class Segment(object):
         """
         self._watchers[watch_type].append(callback)
 
-    def rect(self):
-        """Return the normalized rectangle as ((x1, y1), (x2, y2)) such that
+    def rect(self, normalized=False):
+        """Return the segment rectangle as ((x1, y1), (x2, y2)) such that
         (x1, y1) is the top left corner, and (x2, y2) the bottom right corner.
-
-        Returns
-        -------
-        tuple
-        """
-        return (
-            (self._rect[0][0], self._rect[0][1]),
-            (self._rect[1][0], self._rect[1][1])
-        )
-
-    def renormalize(self, x_factor, y_factor):
-        """Renormalize the segment by applying the given factor
 
         Parameters
         ----------
-        x_factor, y_factor : float
-        """
-        self._rect = [
-            [self._rect[0][0] * x_factor, self._rect[0][1] * y_factor],
-            [self._rect[1][0] * x_factor, self._rect[1][1] * y_factor]
-        ]
-        self._width = self._rect[1][0] - self._rect[0][0]
-        self._height = self._rect[1][1] - self._rect[0][1]
+        normalized : bool
+            If True, the normalized segment is returned
 
-    def left(self):
+        Returns
+        -------
+        tuple of tuple of floats
+            ((x1, y1), (x2, y2))
+        """
+        if normalized:
+            return (
+                (
+                    self._rect[0][0] / self._scene_size[0],
+                    self._rect[0][1] / self._scene_size[1]
+                ),
+                (
+                    self._rect[1][0] / self._scene_size[0],
+                    self._rect[1][1] / self._scene_size[1]
+                )
+            )
+        else:
+            return (
+                (self._rect[0][0], self._rect[0][1]),
+                (self._rect[1][0], self._rect[1][1])
+            )
+
+    def get_q_rect_f(self, normalized=False):
+        """Return the segment as QtCore.QRectF object
+
+        Note the object is re-build at each invocation.
+
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized co-ordinates
+
+        Returns
+        -------
+        QtCore.QRectF
+        """
+        if normalized:
+            rect = self.rect(normalized=True)
+            return QtCore.QRectF(
+                rect[0][0], rect[0][1],
+                rect[1][0] - rect[0][0], rect[1][1] - rect[0][1]
+            )
+        else:
+            return QtCore.QRectF(
+                self._rect[0][0], self._rect[0][1], self._width, self._height
+            )
+
+    def left(self, normalized=False):
         """Return the coordinate of the left side of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized co-ordinate
+
         Returns
         -------
         float
         """
-        return self._rect[0][0]
+        if normalized:
+            return self._rect[0][0] / self._scene_size[0]
+        else:
+            return self._rect[0][0]
 
-    def top(self):
+    def top(self, normalized=False):
         """Return the coordinate of the top side of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized co-ordinate
+
         Returns
         -------
         float
         """
-        return self._rect[0][1]
+        if normalized:
+            return self._rect[0][1] / self._scene_size[1]
+        else:
+            return self._rect[0][1]
 
-    def right(self):
+    def right(self, normalized=False):
         """Return the coordinate of the right side of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized co-ordinate
+
         Returns
         -------
         float
         """
-        return self._rect[1][0]
+        if normalized:
+            return self._rect[1][0] / self._scene_size[0]
+        else:
+            return self._rect[1][0]
 
-    def bottom(self):
+    def bottom(self, normalized=False):
         """Return the coordinate of the bottom side of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized co-ordinate
+
         Returns
         -------
         float
         """
-        return self._rect[1][1]
+        if normalized:
+            return self._rect[1][1] / self._scene_size[1]
+        else:
+            return self._rect[1][1]
 
-    def width(self):
+    def width(self, normalized=False):
         """Return the width of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized width
+
         Returns
         -------
         float
         """
-        return self._width
+        if normalized:
+            return self._width / self._scene_size[0]
+        else:
+            return self._width
 
-    def height(self):
+    def height(self, normalized=False):
         """Return the height of the box
 
+        Parameters
+        ----------
+        normalized : bool
+            If True, return the normalized height
+
         Returns
         -------
         float
         """
-        return self._height
+        if normalized:
+            return self._height / self._scene_size[1]
+        else:
+            return self._height
 
     def fields(self):
         """Return (a copy of) the segment's fields
@@ -222,3 +342,79 @@ class Segment(object):
         list
         """
         return list(self._seeds)
+
+    def associate_object(self, obj, name=None):
+        """Associate an object with that segment.
+
+        This is useful for UI components to keep track of each other.
+
+        Notes
+        -----
+        - By default the association is done using the given object's class
+          name. This approach covers the main use case we have for this
+          (associate a UI object with a segment)
+        - The association is stored using a weak reference, so will not prevent
+          an object from being GCed.
+
+        Parameters
+        ----------
+        obj : object
+            Object to associate with the segment
+        name : str
+            The identifier to associate the object under. If None,
+            the obj.__class__.__name__ will be used.
+        """
+        if name is None:
+            name = obj.__class__.__name__
+        self._objects[name] = weakref.ref(obj)
+
+    def get_associated_object(self, name):
+        """Return an object associated with this segment
+
+        Notes
+        -----
+        A weak reference to an object that gets GCed becomes None. Given that
+        there is no practical use for storing None here, we always assume
+        a value of None means there is no object anymore.
+
+        Parameters
+        ----------
+        name : str or classobj
+            Name the object was associated as. If a class object, then the
+            associated name is name.__name__
+
+        Returns
+        -------
+        object
+            The associated object
+
+        Raises
+        ------
+        NoAssociatedObject
+            If there is no such associated object for the segment
+        """
+        if inspect.isclass(name):
+            name = name.__name__
+        if name in self._objects:
+            deref = (self._objects[name])()
+            if deref is not None:
+                return deref
+        raise NoAssociatedObject()
+
+    def is_associated_to(self, obj):
+        """Checks if this segment is associated to the given object
+
+        Parameters
+        ----------
+        obj : object
+            Object to check against
+
+        Returns
+        -------
+        bool
+        """
+        for name in self._objects:
+            deref = (self._objects[name])()
+            if deref is obj:
+                return True
+        return False

--- a/inselect/lib/segment_scene.py
+++ b/inselect/lib/segment_scene.py
@@ -1,7 +1,4 @@
-import weakref
-import inselect.settings
-from inselect.lib.segment_object import Segment
-from PySide import QtCore, QtGui
+from inselect.lib.segment_object import Segment, NoAssociatedObject
 
 
 class SegmentNotInScene(Exception):
@@ -10,17 +7,8 @@ class SegmentNotInScene(Exception):
     pass
 
 
-class NoAssociatedObject(Exception):
-    """Exception raised when attempting to obtain a non-existent
-    associated object
-    """
-    pass
-
-
 class SegmentScene(object):
-    """The SegmentScene keeps track of all segments in a scene, giving context
-    to the normalized segments and providing a way for UI elements to get
-    notifications in changes in the scene.
+    """The SegmentScene keeps track of all segments in a scene.
 
     The list of segment is ordered in an intuitive prev/next fashion, and
     updated whenever a segment is modified.
@@ -30,30 +18,15 @@ class SegmentScene(object):
     Because segments can be modified directly, events to track update of
     individual segments are on the Segment objects themselves.
 
-    The segment scene can also keep track of objects associated with a
-    particular segment using `associate_object` and `get_associated_object`.
-    This is useful for the UI to keep track of UI components associated with
-    a segment.
-
-    Notes
-    -----
-    - The individual segments are normalized - only the segment scene has
-      knowledge of the context in which the segments are drawn. So any
-      operation based on screen co-ordinates need to go through
-      the SegmentScene.
-
-    - Associating an object does not create an additional reference to the
-      object. It must be kept track of elsewhere.
-
     Parameters
     ----------
     width, height : float or int
-        Width and height of the scene
+        Width and height of the scene. Both default to '1', creating a
+        normalized scene.
     """
-    def __init__(self, width, height):
+    def __init__(self, width=1, height=1):
         self._width = float(width)
         self._height = float(height)
-        self._pixmap = None
         self._segments = []
         self._watchers = {
             'after-segment-add': [],
@@ -61,31 +34,7 @@ class SegmentScene(object):
         }
 
     def add(self, corner_a, corner_b, fields=None):
-        """Add a segment from non-normalized (scene) coordinates
-
-        corner_a and corner_b should both represent one corner of the box,
-        such that the two corners are diagonally opposite. These will always
-        be re-arranged and stored as (top left, bottom right).
-
-        Parameters
-        ----------
-        corner_a, corner_b : tuple of float or int
-            Each corner is (x, y)
-        fields : dict, optional
-
-        Returns
-        -------
-        Segment
-            The created segment
-        """
-        self.add_normalized(
-            (float(corner_a[0])/self._width, float(corner_a[1])/self._height),
-            (float(corner_b[0])/self._width, float(corner_b[1])/self._height),
-            fields
-        )
-
-    def add_normalized(self, corner_a, corner_b, fields=None):
-        """Add a segment from normalized coordinates
+        """Add a segment from scene coordinates
 
         corner_a and corner_b should both represent one corner of the box,
         such that the two corners are diagonally opposite. These will always
@@ -105,12 +54,40 @@ class SegmentScene(object):
         new_segment = Segment(
             (float(corner_a[0]), float(corner_a[1])),
             (float(corner_b[0]), float(corner_b[1])),
+            (self._width, self._height),
             fields
         )
         self._insert(new_segment)
+        # Ensure we are the first watcher, so the segment scene is always
+        # ordered correctly.
+        new_segment.watch('after-corners-update', self._segment_moved)
         for callback in self._watchers['after-segment-add']:
             callback(new_segment)
         return new_segment
+
+    def add_normalized(self, corner_a, corner_b, fields=None):
+        """Add a segment from normalized coordinates
+
+        corner_a and corner_b should both represent one corner of the box,
+        such that the two corners are diagonally opposite. These will always
+        be re-arranged and stored as (top left, bottom right).
+
+        Parameters
+        ----------
+        corner_a, corner_b : tuple of float
+            Each corner is (x, y)
+        fields : dict, optional
+
+        Returns
+        -------
+        Segment
+            The created segment
+        """
+        return self.add(
+            (corner_a[0] * self._width, corner_a[1] * self._height),
+            (corner_b[0] * self._width, corner_b[1] * self._height),
+            fields
+        )
 
     def remove(self, segment):
         """Remove a segment from the scene
@@ -135,10 +112,7 @@ class SegmentScene(object):
         -------
         list of Segment
         """
-        segments = []
-        for s in self._segments:
-            segments.append(s['segment'])
-        return segments
+        return list(self._segments)
 
     def watch(self, watch_type, callback):
         """Add a callback to be invoked when the segment scene is updated
@@ -153,15 +127,12 @@ class SegmentScene(object):
         """
         self._watchers[watch_type].append(callback)
 
-    def _insert(self, new_segment, objects=None):
+    def _insert(self, new_segment):
         """Insert a new segment in the scene
 
         Parameters
         ----------
         new_segment : Segment
-        objects : dict of name to weakref, optional
-            List of objects associated with the segment, stored as weak
-            references
         """
         # Basic insertion algorithm: divide the scene in 20 bands, and order
         # the segments per band (based on top left corner). Within each band,
@@ -170,7 +141,7 @@ class SegmentScene(object):
         new_segment_band = int(new_segment.top()/band_size)
         insert_at = len(self._segments)
         for i in range(len(self._segments)):
-            segment = self._segments[i]['segment']
+            segment = self._segments[i]
             segment_band = segment.top()/band_size
             if new_segment_band > segment_band:
                 continue
@@ -178,124 +149,38 @@ class SegmentScene(object):
                     new_segment.left() < segment.left()):
                 insert_at = i
                 break
-        if objects is None:
-            objects = {}
-        self._segments.insert(insert_at, {
-            'segment': new_segment,
-            'objects': objects
-        })
+        self._segments.insert(insert_at, new_segment)
 
-    def set_segment_corners(self, segment, top_left, bottom_right):
-        """set the given segment's corners from non-normalized (scene)
-        coordinates.
+    def _segment_moved(self, segment):
+        """Call to notify the segment scene a segment has moved
+
+        This allows us to re-order the list
 
         Parameters
         ----------
         segment : Segment
-            The segment to update in the context of this scene
-        top_left, bottom_right : tuple of float or int
-            New co-ordinates
-
-        Raises
-        ------
-        SegmentNotInScene
         """
-        # Ensure we own it.
-        self.get_segment_index(segment)
-        top_left = (
-            float(top_left[0]) / self._width,
-            float(top_left[1]) / self._height
-        )
-        bottom_right = (
-            float(bottom_right[0]) / self._width,
-            float(bottom_right[1]) / self._height
-        )
-        segment.set_corners(top_left, bottom_right)
-        # Now update the scene
-        try:
-            index = self.get_segment_index(segment)
-        except SegmentNotInScene:
-            # One of the watchers decided to delete the segment. That's fine.
-            return
-        objects = self._segments[index]['objects']
+        index = self.get_segment_index(segment)
         del self._segments[index]
-        self._insert(segment, objects)
-
-    def move_segment_corners(self, segment, top_left_delta,
-                               bottom_right_delta=None):
-        """Update the given segment's corners from
-        non-normalized (scene) deltas.
-
-        This will either update both the top left and bottom right corners
-        independently (if both top_left_delta and bottom_right_delta) are
-        defined, or will move both corners equally (if only top_left_delta
-        is defined)
-
-        Parameters
-        ----------
-        segment : Segment
-            The segment to update in the context of this scene
-        top_left_delta : tuple of float or int
-        bottom_right_delta : tuple of float or int, optional
-
-        Raises
-        ------
-        SegmentNotInScene
-        """
-        # Ensure we own it.
-        self.get_segment_index(segment)
-        top_left_delta = (
-            float(top_left_delta[0]) / self._width,
-            float(top_left_delta[1]) / self._height
-        )
-        if bottom_right_delta:
-            bottom_right_delta = (
-                float(bottom_right_delta[0]) / self._width,
-                float(bottom_right_delta[1]) / self._height
-            )
-        segment.move_corners(top_left_delta, bottom_right_delta)
-        # Now update the scene
-        try:
-            index = self.get_segment_index(segment)
-        except SegmentNotInScene:
-            # One of the watchers decided to delete the segment. That's fine.
-            return
-        objects = self._segments[index]['objects']
-        del self._segments[index]
-        self._insert(segment, objects)
+        self._insert(segment)
 
     def set_size(self, width, height):
-        """Sets the size of the scene and re-normalize segments
+        """Sets the size of the scene and scale segments accordingly
 
         Parameters
         ----------
         width, height : float or int
             New width and height fo the scene.
         """
-        w_factor = self._width / float(width)
-        h_factor = self._height / float(height)
-        for s in self._segments:
-            s['segment'].renormalize(w_factor, h_factor)
         self._width = float(width)
         self._height = float(height)
-
-    def set_pixmap(self, pixmap):
-        """Sets the pixmap of the scene.
-
-        This will re-set the width/height of the scene, and re-normalize
-        segments.
-
-        Parameters
-        ----------
-        pixmap : QPixmap
-        """
-        self._pixmap = pixmap
-        self.set_size(pixmap.width(), pixmap.height())
+        for segment in self._segments:
+            segment.set_scene_size(self._width, self._height)
 
     def empty(self):
         """Remove all the segments"""
-        for s in self._segments:
-            s['segment'].prepare_for_remove()
+        for segment in self._segments:
+            segment.prepare_for_remove()
         self._segments = []
 
     def get_segment_index(self, segment):
@@ -314,10 +199,7 @@ class SegmentScene(object):
         ValueError
             If the segment is not in the scene
         """
-        for index in range(len(self._segments)):
-            if self._segments[index]['segment'] is segment:
-                return index
-        raise ValueError()
+        return self._segments.index(segment)
 
     def get_next_segment(self, segment):
         """Return the segment that follows the given one
@@ -344,7 +226,7 @@ class SegmentScene(object):
         else:
             pos = self.get_segment_index(segment)
             segment_index = (pos + 1) % len(self._segments)
-        return self._segments[segment_index]['segment']
+        return self._segments[segment_index]
 
     def get_previous_segment(self, segment):
         """Return the segment that precedes the given one
@@ -371,134 +253,7 @@ class SegmentScene(object):
         else:
             pos = self.get_segment_index(segment)
             segment_index = (pos - 1) % len(self._segments)
-        return self._segments[segment_index]['segment']
-
-    def get_q_rect_f(self, segment):
-        """Return a de-normalized QRectF object representing a segment
-
-        A new QRectF object is build every time.
-
-        Parameters
-        ----------
-        segment : Segment
-
-        Returns
-        -------
-        QtCore.QRectF
-        """
-        return QtCore.QRectF(
-            segment.left() * self._width,
-            segment.top() * self._height,
-            segment.width() * self._width,
-            segment.height() * self._height
-        )
-
-    def get_segment_icon(self, segment):
-        """Return a segment's icon in the scene
-
-        The scene must have a pixmap for this to work.
-
-        Parameters
-        ----------
-        segment : Segment
-
-        Returns
-        -------
-        QtGui.QIcon
-        """
-        icon_size = inselect.settings.get('icon_size')
-        icon_padding = 16
-        icon_background = '#EEE'
-        self.get_segment_index(segment)
-        # Get a scale the selected segment to fit in the icon size
-        pixmap = self._pixmap.copy(
-            int(segment.left() * self._width),
-            int(segment.top() * self._height),
-            int(segment.width() * self._width),
-            int(segment.height() * self._width)
-        )
-        if pixmap.width() > pixmap.height():
-            scale = float(icon_size - icon_padding)/float(pixmap.width())
-        else:
-            scale = float(icon_size - icon_padding)/float(pixmap.height())
-        pixmap = pixmap.scaled(
-            pixmap.width() * scale,
-            pixmap.height() * scale,
-            transformMode=QtCore.Qt.SmoothTransformation
-        )
-        # Create a background pixmap
-        background = QtGui.QPixmap(icon_size, icon_size)
-        painter = QtGui.QPainter(background)
-        painter.fillRect(QtCore.QRectF(0, 0, icon_size-1, icon_size-1),
-                         QtGui.QColor(icon_background))
-        painter.setPen(QtCore.Qt.DashLine)
-        painter.drawRect(QtCore.QRectF(0, 0, icon_size-1, icon_size-1))
-        painter.drawPixmap(
-            (icon_size - pixmap.width()) / 2,
-            (icon_size - pixmap.height()) / 2,
-            pixmap
-        )
-        painter.end()
-        # Create the icon
-        icon = QtGui.QIcon()
-        icon.addPixmap(background)
-        return icon
-
-    def associate_object(self, name, obj, segment):
-        """Associate an object with a particular segment in this scene
-
-        Parameters
-        ----------
-        name : str
-            Name to store the object under
-        obj : object
-            Object to associate with the segment
-        segment : Segment
-            Segment to associate the object with
-
-        Raises
-        ------
-        ValueError
-            If the segment is not in this scene
-        """
-        index = self.get_segment_index(segment)
-        self._segments[index]['objects'][name] = weakref.ref(obj)
-
-    def get_associated_object(self, name, segment):
-        """Return an object associated with a segment in this scene
-
-        Notes
-        -----
-        A weak reference to an object that gets GCed becomes None. Given that
-        there is no practical use for storing None here, we always assume
-        a value of None means there is no object anymore.
-
-        Parameters
-        ----------
-        name : str
-            Name the object was associated as
-        segment : Segment
-            Segment the object was associated with
-
-        Returns
-        -------
-        object
-            The associated object
-
-        Raises
-        ------
-        ValueError
-            If the segment is not in the scene
-        NoAssociatedObject
-            If there is no such associated object for the segment
-        """
-        index = self.get_segment_index(segment)
-        objs = self._segments[index]['objects']
-        if name in objs:
-            deref = (objs[name])()
-            if deref is not None:
-                return deref
-        raise NoAssociatedObject()
+        return self._segments[segment_index]
 
     def get_associated_segment(self, obj):
         """Return a segment associated with an object in this scene
@@ -514,12 +269,10 @@ class SegmentScene(object):
 
         Raises
         ------
-        NoAssociatedOjbect
+        NoAssociatedObject
             If the object is not found in the scene
         """
-        for s in self._segments:
-            for name in s['objects']:
-                deref = (s['objects'][name])()
-                if deref is obj:
-                    return s['segment']
+        for segment in self._segments:
+            if segment.is_associated_to(obj):
+                return segment
         raise NoAssociatedObject()


### PR DESCRIPTION
- Split functionality between GraphicsView and GraphicsSCene so that only GraphicsScene need to know about BoxResizable. All other components work with the Segment object only;
- Make the segment object store non-normalized values, and move functionality from the SegmentScene to the Segment object. This makes the API more readable, and normalizing as late as possible is proably best given that we're using floats.

While InselectMainWindow still needs work, this should be the last refactoring to affect GraphicsView, GraphicsScene, BoxResizable, SegmentScene, Segment and Annotator significantly.

The Annotator object was also changed to have a larger image and initialize fields with common values when editing multiple segments.
