### PR TITLE
resolve references securely

### DIFF
--- a/website/content/news/2015-11-23-plos-one-paper.md
+++ b/website/content/news/2015-11-23-plos-one-paper.md
@@ -1,5 +1,5 @@
 Title: PLOS ONE paper published
 
 Our paper
-[*Inselect: automating the digitization of natural history collections*](http://dx.doi.org/10.1371/journal.pone.0143402)
+[*Inselect: automating the digitization of natural history collections*](https://doi.org/10.1371/journal.pone.0143402)
 was published today.

--- a/website/content/news/2016-03-29-inselect-webinar.md
+++ b/website/content/news/2016-03-29-inselect-webinar.md
@@ -3,7 +3,7 @@ Title: Inselect webinar
 Ben Price and Lawrence Hudson (Natural History Museum London) gave a webinar
 *Insights into Inselect: automating image processing, barcode reading, and
 validation of user-defined metadata*. The webinar is available as a
-[video](https://dx.doi.org/10.6084/m9.figshare.3208021.v2) and via
+[video](https://doi.org/10.6084/m9.figshare.3208021.v2) and via
 [Adobe Connect](https://idigbio.adobeconnect.com/p7qo63aeo4a/) (additional
 software required).
 

--- a/website/content/pages/documentation.md
+++ b/website/content/pages/documentation.md
@@ -6,11 +6,11 @@ You can find out about Inselect from
 * the [iDigBio](https://www.idigbio.org/) webinar, *Insights into Inselect:
 automating image processing, barcode reading, and validation of user-defined
 metadata*, available as a
-[video](https://dx.doi.org/10.6084/m9.figshare.3208021.v2) and via
+[video](https://doi.org/10.6084/m9.figshare.3208021.v2) and via
 [Adobe Connect](https://idigbio.adobeconnect.com/p7qo63aeo4a/) (additional
 software required), and
 * the PLOS ONE paper
-[*Inselect: automating the digitization of natural history collections*](https://dx.doi.org/10.1371/journal.pone.0143402).
+[*Inselect: automating the digitization of natural history collections*](https://doi.org/10.1371/journal.pone.0143402).
 
 ### Exercises
 We plan to create comprehensive user documentation for Inselect.

--- a/website/content/pages/faqs.md
+++ b/website/content/pages/faqs.md
@@ -4,7 +4,7 @@ Title: FAQs
 > Hudson LN, Blagoderov V, Heaton A, Holtzhausen P, Livermore L, Price BW,
 van der Walt S and Smith VS. 2015. *Inselect: automating the digitization of
 natural history collections*. PLOS ONE. 10 (11), e0143402.
-[10.1371/journal.pone.0143402](http://dx.doi.org/10.1371/journal.pone.0143402).
+[10.1371/journal.pone.0143402](https://doi.org/10.1371/journal.pone.0143402).
 
 ### What license does Inselect use?
 The Inselect software is licensed under a


### PR DESCRIPTION
Hello! The old `dx` subdoimain of the DOI resolver still works (probably redirected), but this updates the hyperlinks to using the new resolver. Cheers :-)